### PR TITLE
update calling busted

### DIFF
--- a/nginx_openresty/spec/runner.lua
+++ b/nginx_openresty/spec/runner.lua
@@ -69,7 +69,7 @@ local runner = require 'busted.runner'
 return function(...)
   local params = {...}
   if #params == 0 then
-    params = {batch = true}
+    params = {standalone = false, batch = true}
   end
   setup()
   local _, result = pcall(runner, params)


### PR DESCRIPTION
Busted 2.0.rc11-0 has the following main file:

> require 'busted.runner'({ standalone = false })

Previous Busted versions had batch = true instead of standalone = false.
Use both of them to be compatible with both Busted versions.
